### PR TITLE
Make the repo pip-installable

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,28 @@
+name: Test
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install package
+        run: pip install -e .
+
+      - name: Smoke-test imports
+        run: python -c "import cherab; import raysect; import main"
+
+      - name: Run smoke scripts
+        run: python testingScripts/cameraBoxAddition.py

--- a/README.md
+++ b/README.md
@@ -6,6 +6,38 @@ routine. Each program requires config files to be run and some specific file org
 but the general structure is this:
 
 
+## Installation
+
+Requires Python 3.11 or 3.12.
+
+```bash
+git clone https://github.com/ORNL-Fusion/Emis3D
+cd Emis3D
+python3.12 -m venv .venv
+source .venv/bin/activate
+pip install -e .
+```
+
+Or, with [`uv`](https://docs.astral.sh/uv/):
+
+```bash
+uv venv --python 3.12
+uv pip install -e .
+```
+
+### Python Compatibility
+
+`cherab` and `raysect` ship Cython-compiled C extensions that don't build
+on CPython 3.13+ — the `_PyLong_AsByteArray` API changed in that release.
+Lift the cap once `cherab` ships a build compatible with newer Python.
+
+### Troubleshooting
+
+If `pip install -e .` fails with a `clang` / `_PyLong_AsByteArray` error,
+the Python version is too new. Check with `python --version` and recreate
+the venv with 3.12.
+
+
 INPUTS within /inputs/{tokamakName}/
 ------------------------------------------------------------------------------------------------
 eqdsks/                           :: The equilbrium files for your runs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,27 @@
+[build-system]
+requires = ["setuptools>=64"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "emis3d"
+version = "0.1.0"
+description = "Fit synthetic radiation distributions against tokamak SXR/bolometer measurements."
+readme = "README.md"
+license = { file = "LICENSE" }
+requires-python = ">=3.11,<3.13"
+dependencies = [
+    "cherab>=1.5.0",
+    "raysect==0.8.1.*",
+    "numpy<2.0",
+    "scipy>1.16.3",
+    "matplotlib>=3.10.8",
+    "numba>=0.64.0",
+    "lmfit>=1.3.4",
+    "freeqdsk>=0.5.2",
+    "h5py",
+    "pandas",
+    "pyyaml",
+]
+
+[tool.setuptools]
+packages = ["main"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,0 @@
-matplotlib>=3.10.8
-raysect>=0.90
-numpy>=2.4.3
-cherab>=1.5.0
-lmfit>=1.3.4
-scipy>1.16.3
-freeqdsk>=0.5.2
-numba>=0.64.0


### PR DESCRIPTION
Closes #11.

## Summary

- Replaces `requirements.txt` with `pyproject.toml`, declaring `emis3d` as
  an installable package. `pip install -e .` now works and makes `main`
  importable from any cwd.
- Pins dependencies to a set the resolver can actually satisfy. The old
  list asked for `raysect>=0.9` and `numpy>=2.4.3`, but `cherab==1.5.0`
  hard-pins `raysect==0.8.1.*` and `numpy<2.0` — no solution existed.
- Caps Python at `>=3.11,<3.13`. raysect 0.8.1's Cython extensions don't
  build on CPython 3.13+ (`_PyLong_AsByteArray` ABI change); scipy 1.16+
  requires `>=3.11`, so the floor moves up too.
- Adds `h5py`, `pandas`, `pyyaml` — imported by `main/` but missing from
  the old list.
- Adds a CI workflow that runs `pip install -e .` on Python 3.11 and 3.12
  and smoke-imports `cherab`, `raysect`, and `main`.
- Updates the README with an install section, a note on the Python window,
  and a troubleshooting pointer for the most common failure.

## Test plan

- [x] CI passes on Python 3.11 and 3.12 (verified on fork before opening).
- [x] Editable install works from a clean venv: `uv venv --python 3.12 && uv pip install -e .` followed by `python -c "import main"` from an arbitrary cwd.
- [ ] Reviewer can reproduce by following the README install steps verbatim.