### PR TITLE
ci: add pytest coverage reporting

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,7 @@ name: Test
 
 on:
   push:
+    branches: [main]
   pull_request:
 
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,10 +19,10 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install package
-        run: pip install -e . pytest
+        run: pip install -e ".[test]"
 
       - name: Smoke-test imports
         run: python -c "import cherab; import raysect; import main"
 
       - name: Run unit tests
-        run: python -m pytest tests/ -v
+        run: python -m pytest tests/ -v --cov=main --cov-report=term-missing

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,5 +24,17 @@ dependencies = [
     "dill",
 ]
 
+[project.optional-dependencies]
+test = [
+    "pytest",
+    "pytest-cov",
+]
+
 [tool.setuptools]
 packages = ["main"]
+
+[tool.coverage.run]
+source = ["main"]
+
+[tool.coverage.report]
+show_missing = true


### PR DESCRIPTION
- Add `pytest-cov` optional dependency for measuring test coverage
- Automatically test coverage of main package in CI
 
TBD: we can set a lower limit on test coverage percentage, that means that new code cannot lower the test coverage percentage. But it's also OK to just keep the coverage measurement for visibility.

After this PR, test coverage is reported in a table in the CI run, see for example: https://github.com/ORNL-Fusion/Emis3D/actions/runs/28136677588/job/83324970250?pr=26. The report looks as follows, where each file shows the coverage percentage, and line (ranges) that aren't exercised.
```
================================ tests coverage ================================
_______________ coverage: platform linux, python 3.11.15-final-0 _______________

Name                       Stmts   Miss  Cover   Missing
--------------------------------------------------------
main/Diagnostic.py           204    187     8%   48-51, 58-105, 114-122, 143-338, 350-398, 405, 417-515, 523-532
main/Emis3D.py               559    493    12%   163-168, 182-195, 221, 229-235, 243-294, 305-329, 340-350, 360-407, 428-449, 461-530, 537-594, 603-641, 649-707, 719-802, 810-812, 816-817, 831-882, 890-967, 976-1008, 1017-1105, 1114-1122, 1127-1157, 1162-1176, 1184-1263, 1270-1286, 1295-1347, 1352-1382, 1394-1409, 1421-1423
main/Fieldline_Tracer.py      87     80     8%   41-45, 51-148, 152-180
main/Globals.py                9      0   100%
main/Tokamak.py              587    546     7%   85-99, 106-131, 142-162, 168-190, 200-234, 240-360, 370-407, 421-426, 434-436, 442-454, 464-485, 492-534, 546-624, 643-773, 780-799, 809-906, 932-997, 1002, 1016-1029, 1042-1130, 1139-1140, 1148-1165, 1185-1323
main/Util.py                 241    112    54%   25-34, 45, 47, 77, 80, 104, 130, 145, 155, 169-182, 189-209, 222-233, 237-238, 255-261, 292-296, 346-351, 355-365, 370-380, 438, 485-506, 515-518, 526-528
main/Util_emis3D.py          184     31    83%   79, 88, 140-143, 269, 283, 316-317, 372, 401-402, 421, 461, 466-484, 495-504, 514-517, 567
main/Util_plotting.py         56     56     0%   6-152
main/Util_radDist.py         117     61    48%   44-56, 75-85, 104-114, 132-142, 165-178, 224-239, 345-358
main/__init__.py               5      0   100%
main/radDist.py              472    420    11%   39-44, 57, 70-80, 95-112, 138-147, 160, 188-195, 207-210, 239-277, 289-292, 304-419, 433-603, 610-650, 670-756, 763, 767-789, 822-844, 847, 855-891, 910-932, 946-953, 976-994, 1000-1018, 1037-1099, 1113-1120, 1140-1162, 1180-1195, 1209-1212, 1229-1255, 1274-1291, 1305-1308
main/radDistFitting.py       115     17    85%   41-42, 109-112, 188-191, 195-199, 215-216
main/test_util.py            160    160     0%   9-297
--------------------------------------------------------
TOTAL                       2796   2163    23%
======================== 122 passed, 1 warning in 3.63s ========================
```

Drive-by fix:
- CI runs twice on PRs because it triggered on both `pull_request` and `push`, but it should only trigger on `push` to `main`. So I narrowed the trigger condition.

Closes #25