### PR TITLE
29 reproducible bolometer observations with a fixed seed

### DIFF
--- a/main/radDist.py
+++ b/main/radDist.py
@@ -17,7 +17,8 @@ import logging
 import numpy as np
 from cherab.tools.emitters import RadiationFunction
 from raysect.optical import VolumeTransform  # type: ignore
-from raysect.core import SerialEngine
+from raysect.core.workflow import SerialEngine
+from raysect.core.math.random import seed as _raysect_seed
 
 import main.Util_radDist as Util_radDist
 
@@ -38,6 +39,7 @@ from abc import ABC, abstractmethod
 # For NIMROD class
 import json
 from cherab.core.math.interpolators.interpolators3d import Interpolate3DLinear
+
 
 class RadDist(ABC):
     """Parent RadDist class."""
@@ -99,10 +101,28 @@ class RadDist(ABC):
 
         Required values in config file:
         pixelSamples    :: Resolution of the sightline. Higher = better, but takes longer.
+
+        Optional values:
+        seed            :: Integer RNG seed. When set, observations render in-process
+                           so the result is reproducible (a single deterministic draw).
+
         """
 
         boloCameras = self.tokamak.bolometers
+        # TODO: pixelSamples, numProcessors, and seed are raysect/observe options,
+        # not bolometer properties. Move them into a dedicated config group (e.g.
+        # observe_opts) instead of overloading BOLOMETER_PROPS.
         pixelSamples = self.info["BOLOMETER_PROPS"]["pixelSamples"]
+
+        seed = self.info["BOLOMETER_PROPS"].get("seed")
+        if seed is not None:
+            # Seed once before observing.
+            #
+            # Only when used in combination with a serial rendering engine does this
+            # lead to reproducible observes.
+            #
+            # See: https://github.com/ORNL-Fusion/Emis3D/issues/29
+            _raysect_seed(seed)
 
         for bolo_ in boloCameras:
             # --- Either does the top or bottom loop depending on on if there is an extra bolometerCamera layer
@@ -1334,6 +1354,7 @@ class SquareTube(RadDist):
 
         return [[float(phi)] for _ in range(numChan)]
 
+
 class NIMROD(RadDist):
     """
     Takes emissivity data from a timestep of a NIMROD 3D MHD simulation
@@ -1357,12 +1378,12 @@ class NIMROD(RadDist):
         config={},
     ):
 
-        super(NIMROD, self).__init__(
-            config=config or {}
-        )
+        super(NIMROD, self).__init__(config=config or {})
         self.info["distType"] = "NIMROD"
         self.info["emissionNames"] = ["NIMROD"]
-        self.info["startR"] = int(timestep) # haphazard way of making the savefile have the timestep in it
+        self.info["startR"] = int(
+            timestep
+        )  # haphazard way of making the savefile have the timestep in it
         self.info["startZ"] = int(timestep)
 
         self._build_tokamak(
@@ -1371,7 +1392,6 @@ class NIMROD(RadDist):
             reflections=False,
             eqFileName=self.info["eqFileName"],
         )
-
 
         str_ = f"→ Building NIMROD radDist"
         logger.info("%s", str_)
@@ -1389,7 +1409,9 @@ class NIMROD(RadDist):
         self.rmax = max(self.r_list)
         self.zmin = min(self.z_list)
         self.zmax = max(self.z_list)
-        self.interp_operator = Interpolate3DLinear(self.z_list, self.r_list, self.phi_list, self.emis_values)
+        self.interp_operator = Interpolate3DLinear(
+            self.z_list, self.r_list, self.phi_list, self.emis_values
+        )
 
     def _evaluate(
         self,
@@ -1415,7 +1437,7 @@ class NIMROD(RadDist):
 
         # breakpoint()
         localEmisVec = np.zeros(len(z))
-        #if (z >= self.zmin) and (z <= self.zmax) and (R >= self.rmin) and (R <= self.rmax):
+        # if (z >= self.zmin) and (z <= self.zmax) and (R >= self.rmin) and (R <= self.rmax):
         for indx in range(len(z)):
             zinst = z[indx]
             Rinst = R[indx]
@@ -1423,9 +1445,14 @@ class NIMROD(RadDist):
                 phiinst = phi[indx]
             else:
                 phiinst = phi
-            if phiinst<0:
+            if phiinst < 0:
                 phiinst = phiinst + 2.0 * np.pi
-            if (zinst >= self.zmin) and (zinst <= self.zmax) and (Rinst >= self.rmin) and (Rinst <= self.rmax):
+            if (
+                (zinst >= self.zmin)
+                and (zinst <= self.zmax)
+                and (Rinst >= self.rmin)
+                and (Rinst <= self.rmax)
+            ):
                 localEmisVec[indx] = self.interp_operator(zinst, Rinst, phiinst)
             else:
                 localEmisVec[indx] = 0.0

--- a/main/radDist.py
+++ b/main/radDist.py
@@ -51,6 +51,9 @@ class RadDist(ABC):
             self.info["startPhi"] = self.info["injectionLocation"]
             self.info["startPhiRad"] = np.deg2rad(self.info["injectionLocation"])
 
+        # Holds computed results; initialized here so it always exists.
+        self.data = {}
+
     def _build_tokamak(
         self,
         tokamakName="",
@@ -446,9 +449,6 @@ class RadDist(ABC):
 
         # --- Initialize the data storage arrays
         boloCameras = self.tokamak.bolometers
-        if not hasattr(self, "data"):
-            self.data = {}
-
         self.data[units] = {}
         self.data[f"{units}_error"] = {}
         self.data[units]["channelOrder"] = {}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,3 +38,9 @@ source = ["main"]
 
 [tool.coverage.report]
 show_missing = true
+
+[tool.pytest.ini_options]
+markers = [
+    "cherab: slow tests that build a scene and ray-trace with cherab (deselected by default)",
+]
+addopts = "-m 'not cherab'"

--- a/tests/test_seeded_observation_reproducible.py
+++ b/tests/test_seeded_observation_reproducible.py
@@ -1,0 +1,57 @@
+"""
+tests/test_seeded_observation_reproducible.py
+=============================================
+Regression test for reproducible Cherab observations.
+
+With an RNG seed set in ``BOLOMETER_PROPS``, an ``ElongatedRing`` observed twice
+yields identical per-channel brightness. ElongatedRing needs no equilibrium
+g-file, so this depends only on the in-repo DIII-D geometry.
+
+Opt-in (slow): ``foil.observe()`` ray-traces, so this is deselected by default
+via the ``cherab`` marker. Run it explicitly with:
+
+    pytest -m cherab
+"""
+
+import numpy as np
+import pytest
+
+# `pytestmark` applies a marker to *every* test in this file. The `cherab` marker
+# (registered in pyproject.toml) means "slow, needs cherab": these tests are
+# deselected from a normal `pytest` run and execute only via `pytest -m cherab`.
+pytestmark = pytest.mark.cherab
+
+BOLO_GROUP = "SX90PF_UP"
+CONFIG = {
+    "distType": "ElongatedRing",
+    "tokamakName": "DIII-D",
+    "units": "Brightness",
+    "injectionLocation": 225,
+    "eqFileName": "",
+    "sigma_R": 0.3,
+    "sigma_z": 0.25,
+    "rotationAngle": 30,
+    "BOLOMETER_PROPS": {"pixelSamples": 200, "numProcessors": 1, "seed": 12345},
+}
+
+
+def test_seeded_observation_is_reproducible():
+    """Two seeded observes of one structure produce bit-identical brightness."""
+    pytest.importorskip("cherab", reason="cherab not installed")
+    pytest.importorskip("raysect", reason="raysect not installed")
+    import main.radDist as radDist
+
+    rD = radDist.ElongatedRing(startR=2.055, startZ=0.414, config=dict(CONFIG))
+    rD.tokamak.bolometers = [b for b in rD.tokamak.bolometers if b.name == BOLO_GROUP]
+
+    def observe():
+        rD.bolos_observe()
+        return np.asarray(
+            rD.data[rD.info["units"]]["elongatedRing"][BOLO_GROUP], dtype=float
+        )
+
+    first = observe()
+    second = observe()
+
+    assert first.max() > 0.0, "observation is empty; nothing meaningful to compare"
+    np.testing.assert_array_equal(first, second)


### PR DESCRIPTION
## Context
Raysect sets the `seed` only in the primary worker, additional workers still use a random seed, so the result is still not deterministic. A possible upstream fix could be that raysect workers choose a distinct but non-random seed (based on `seed`), so we could follow up with that if this fix is too slow.

## Solution
- Introduced a new setting: `BOLOMETER_PROPS.seed`. Setting this seed to a specific number will set the seed in raysect, and restrict raysect to using only a single worker.

## Drive-by fixes
- Initialize `RadDist.data` in the constructor.

## Tests
- Add a test that verifies that subsequent observes are exactly the same.

Closes #29 